### PR TITLE
Added support for BO2s

### DIFF
--- a/form.py
+++ b/form.py
@@ -725,6 +725,11 @@ ui_string = """<?xml version="1.0" encoding="UTF-8"?>
          </item>
          <item>
           <property name="text">
+           <string>2</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>3</string>
           </property>
          </item>
@@ -823,6 +828,11 @@ ui_string = """<?xml version="1.0" encoding="UTF-8"?>
          <item>
           <property name="text">
            <string>1</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>2</string>
           </property>
          </item>
          <item>

--- a/static/form.ui
+++ b/static/form.ui
@@ -722,6 +722,11 @@
          </item>
          <item>
           <property name="text">
+           <string>2</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>3</string>
           </property>
          </item>
@@ -817,6 +822,11 @@
          <item>
           <property name="text">
            <string>1</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>2</string>
           </property>
          </item>
          <item>


### PR DESCRIPTION
This adds support for BO2s.

Changes:

1. form.py/form.ui: Added 2 to the best of dropdowns

2. tourneydefs.py: 
      - process_game() now sets `match` to `self.matches[match_id]` to shorten character count in later lines
      - process_game() accounts for best of 2s. If there's a tie, `winner_index = 3`.
      - game_complete() adds 0.5 points to each team in the match if they tied in a BO2.