### PR TITLE
Challonge BoX fix

### DIFF
--- a/tourneydefs.py
+++ b/tourneydefs.py
@@ -139,9 +139,11 @@ class Tournament(BaseModel):
                 self.matches[match_id].scores = [0, 0]
                 match["scores"] = match["scores_csv"].split("-")
                 match["scores"] = list(map(int, match["scores"]))
+                if match["scores"][0] == match["scores"][1]:
+                    self.matches[match_id].best_of = sum(match["scores"])
+                else:
+                    self.matches[match_id].best_of = (max(match["scores"]) * 2) - 1
                 if match["winner_id"] == match["player1_id"]:
-                    # reset best_of and scores
-                    self.matches[match_id].best_of = (match["scores"][0] * 2) - 1
                     # process index 1 first
                     match_count = match["scores"][1]
                     while match_count > 0:
@@ -152,7 +154,6 @@ class Tournament(BaseModel):
                         self.game_complete(scheduleid, 0)
                         match_count -= 1
                 else:
-                    self.matches[match_id].best_of = (match["scores"][1] * 2) - 1
                     match_count = match["scores"][0]
                     while match_count > 0:
                         self.game_complete(scheduleid, 0)

--- a/udts.py
+++ b/udts.py
@@ -150,6 +150,7 @@ def open_challonge():
                 window.config["use_challonge"] = True
                 window.config["challonge_id"] = text
                 force_refresh_ui()
+                show_error("CHALLONGE_WARNING")
             else:
                 show_error("CHALLONGE_PARSE_FAIL")
 

--- a/udtsconfig.py
+++ b/udtsconfig.py
@@ -19,4 +19,8 @@ ERRORS = {
     "SAVE_FILE_MISSING": {
         "title": "Could not load from file!", 
         "message": "The default tournament configuration file could not be found. Loading empty tournament."},
+    "CHALLONGE_WARNING" : {
+        "title": "Please read!",
+        "message": "Challonge does NOT inform us as to how many games are in a match. Please double check your imported matches, and be sure to adjust the best-ofs appropriately."
+    }
 }


### PR DESCRIPTION
BoX will now be more accurate when importing from Challonge. 

Changes:

1. tourneydefs.py:
    - Moved best_of assignment outside of if/else, added partial BoY detection where Y is even.
2. udtsconfig.py
    - Added an "error" (really just there for the pop-up) that prompts the user to check over the imported matches due to Challonge API lacking any best_of fields.
3. udts.py
    - Above error shows after importing from Challonge