### PR TITLE
Update how-to-contribute.md

### DIFF
--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -26,4 +26,5 @@ A bit more in-depth, but avoids installing VSCode if you don't want to.  You can
 4. Install `pipenv`: `pip install pipenv`
 5. Create a lock file: `pipenv lock`
 6. Create the environment: `pipenv install --python 3.8`
-7. Run the app: `pipenv run udts.py`
+7. Activate the development environment: `pipenv shell`
+8. Run the program: `python udts.py`


### PR DESCRIPTION
The virtual environment needs to be activated before running the program
in a non-VS Code setup.

With the currently suggested steps, number 7. is failing for me:
```bash
$ pipenv run udts.py
Error: the command udts.py could not be found within PATH or Pipfile's [scripts].
```

The environment needs to be activated first as suggested by `pipenv install`. The following works
```bash
$ pipenv shell
Launching subshell in virtual environment...
$ (updatethestream-IVCc2vaZ) python udts.py
```

To quit the environment simply `exit` the shell. This restores the original session that ran `pipenv shell`.