### PR TITLE
Simplified setup instructions

### DIFF
--- a/how-to-contribute.md
+++ b/how-to-contribute.md
@@ -24,7 +24,6 @@ A bit more in-depth, but avoids installing VSCode if you don't want to.  You can
 2. Install [Python 3.8](https://www.python.org/ftp/python/3.8.8/python-3.8.8-amd64.exe)
 3. Clone the repository into a folder: `git clone https://github.com/chhopsky/updatethestream.git`
 4. Install `pipenv`: `pip install pipenv`
-5. Create a lock file: `pipenv lock`
-6. Create the environment: `pipenv install --python 3.8`
-7. Activate the development environment: `pipenv shell`
-8. Run the program: `python udts.py`
+5. Create the environment: `pipenv install`
+6. Activate the development environment: `pipenv shell`
+7. Run the program: `python udts.py`


### PR DESCRIPTION
Steps 5. and 6. can be merged.
Simply running `pipenv install` is easier. Less typing and less steps means there's less room for errors as well.