### PR TITLE
[UDTS-64] Nicer GitHub Workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -104,7 +104,7 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
-        repository: 'chhopsky/chhopsky.github.io'
+        repository: ${{ secrets.WEB_REPO }}
         token: ${{ secrets.GH_PAT }}
         path: 'website'
         fetch-depth: 0
@@ -118,6 +118,8 @@ jobs:
         fi
         cp ${{ matrix.asset_name }}.zip website/builds/$folder/${{ steps.foldername.outputs.foldername }}.zip
         cd website
+        git config user.name "runner"
+        git config user.email "runner@${{ matrix.os }}.local"
         git add .
         git commit -m "Upload build of commit ${GITHUB_SHA:0:7}"
         git push

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   test:
     name: Code test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: macos-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,7 @@ name: Update the Stream
 on:
   push:
     branches: [ development ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main, development ]
 
@@ -21,7 +22,6 @@ jobs:
             asset_name: udts-macos-x86_64-${{ github.run_number }}
           - os: windows-latest
             asset_name: udts-win64-${{ github.run_number }}
-
 
     steps:
     - uses: actions/checkout@v2
@@ -59,17 +59,51 @@ jobs:
         cp *.md dist/
       shell: bash
 
+    - uses: nelonoel/branch-name@v1.0.1
+
+    - name: Change folder name
+      id: foldername
+      run: |
+        if [ "$BRANCH_NAME" == "main" ]; then
+          version=$(egrep -oP '"version": "\K(\d+\.?)*)')
+          foldername=udts-$version
+        else
+          foldername=udts-$(date '+%Y%m%d')-${GITHUB_SHA:0:7}
+        fi
+        mv dist/ $foldername
+        echo "::set-output name=foldername::$foldername"
+      shell: bash
+
     - uses: vimtor/action-zip@v1
       with:
-        files: dist/
+        files: ${{ steps.foldername.outputs.foldername }}
         recursive: false
-        dest: udts.zip
+        dest: ${{ matrix.asset_name }}.zip
 
-    - uses: svenstaro/upload-release-action@v2
-      name: Publish release
+    - uses: softprops/action-gh-release@v1
+      if: ${{ env.BRANCH_NAME == 'main' && github.ref_type == 'tag' }}
       with:
-        file: udts.zip
-        asset_name: ${{ matrix.asset_name }}.zip
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}    
+        draft: true
+        files: ${{ matrix.asset_name }}.zip
+        body_path: ${{ github.workspace }}/patchnotes.md
 
+    - uses: actions/checkout@v2
+      with:
+        repository: 'chhopsky/chhopsky.github.io'
+        token: ${{ secrets.GH_PAT }}
+        path: 'website'
+        fetch-depth: 0
+
+    - name: Publis build to website
+      run:
+        if [ "$BRANCH_NAME" == "main" ]; then
+          folder=releases
+        else
+          folder=development
+        fi
+        cp udts.zip website/builds/$folder/${{ steps.foldername.outputs.foldername }}.zip
+        cd website
+        git add .
+        git commit -m "Upload build of commit ${GITHUB_SHA:0:7}"
+        git push
+      shell: bash

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,29 @@ on:
     branches: [ main, development ]
 
 jobs:
+  test:
+    name: Code test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+          cache: 'pipenv'
+          cache-dependency-path: '**/Pipfile'
+      - name: Setup Pipenv
+        run: |
+          python -m pip install -U pip pipenv
+          pipenv install --deploy --dev
+      - name: Test
+        run: pipenv run pytest tests.py
+
   build:
+    needs: test
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -29,16 +51,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.8"
-    - name: Setup Pipenv
-      run: |
-        python -m pip install --upgrade pip pipenv wheel
-        pipenv install --deploy --dev
-
-    - name: Test with pytest
-      run: pipenv run pytest tests.py
+        cache: 'pipenv'
+        cache-dependency-path: '**/Pipfile'
 
     - name: Build package
       run: |
+        python -m pip install -U pip pipenv
         pipenv install -d pyinstaller
         pipenv run pip uninstall typing -y
         pipenv run pyinstaller --onefile --icon=static/chhtv.ico udts.py
@@ -94,8 +112,8 @@ jobs:
         path: 'website'
         fetch-depth: 0
 
-    - name: Publis build to website
-      run:
+    - name: Publish build to website
+      run: |
         if [ "$BRANCH_NAME" == "main" ]; then
           folder=releases
         else

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -81,9 +81,9 @@ jobs:
       run: |
         if [ "$BRANCH_NAME" == "main" ]; then
           version=$(egrep -oP '"version": "\K(\d+\.?)*)')
-          foldername=udts-$version
+          foldername=udts-v$version-${{ matrix.os }}
         else
-          foldername=udts-$(date '+%Y%m%d')-${GITHUB_SHA:0:7}
+          foldername=udts-$(date '+%Y%m%d')-${GITHUB_SHA:0:7}-${{ matrix.os }}
         fi
         mv dist/ $foldername
         echo "::set-output name=foldername::$foldername"
@@ -116,7 +116,7 @@ jobs:
         else
           folder=development
         fi
-        cp udts.zip website/builds/$folder/${{ steps.foldername.outputs.foldername }}.zip
+        cp ${{ matrix.asset_name }}.zip website/builds/$folder/${{ steps.foldername.outputs.foldername }}.zip
         cd website
         git add .
         git commit -m "Upload build of commit ${GITHUB_SHA:0:7}"


### PR DESCRIPTION
Main changes:

1 .Build on every commit to development and only on tag pushes to main (only for commits *after* this one is merged!)
2. Folder name is now utds-dev-<timestamp>-<sha>-<os>.zip on dev builds and utds-<release tag>-<os>.zip for main builds.
3. Publish a release only after build on main branch
4. On every build upload artifacts (zip file) to `https://chhopsky.github.io/builds`. **Personal Access Token missing!**
5. For now all builds will fail because of 3. This also means that this hasn't been properly tested (!)

We need a PA Token with access to the web repo in order for the push to go through.
It needs to be saved as a secret for this repo under the name GH_PAT for it to work (can be changed on the workflow file line 93)
The target repo is read from the WEB_REPO secret.